### PR TITLE
Make sure plugins used by the tests are built and copied to the lightdb_test target

### DIFF
--- a/plugins/blur/CMakeLists.txt
+++ b/plugins/blur/CMakeLists.txt
@@ -24,5 +24,5 @@ target_link_libraries(blur ${BLUR_LIB_DEPENDENCIES})
 
 ADD_CUSTOM_COMMAND(TARGET blur
         POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:blur> ${PROJECT_SOURCE_DIR}/..
+        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:blur> ${CMAKE_INSTALL_PREFIX}
         )

--- a/plugins/yolo/CMakeLists.txt
+++ b/plugins/yolo/CMakeLists.txt
@@ -8,6 +8,7 @@ include_directories(/home/bhaynes/projects/visualcloud/core/catalog/include)
 include_directories(/home/bhaynes/projects/visualcloud/core/video/include)
 include_directories(/home/bhaynes/projects/visualcloud/core/physical/include)
 include_directories(/home/bhaynes/projects/visualcloud/core/utility/include)
+include_directories(/home/bhaynes/projects/visualcloud/core/pool/include)
 include_directories(/home/bhaynes/projects/darknet/include)
 include_directories(/opt/nvidia/Video_Codec_SDK_7.1.9/Samples/common/inc)
 include_directories(/opt/intel/compilers_and_libraries_2018.3.222/linux/ipp/include)
@@ -26,5 +27,5 @@ target_link_libraries(yolo ${YOLO_LIB_DEPENDENCIES})
 
 ADD_CUSTOM_COMMAND(TARGET yolo
         POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:yolo> ${PROJECT_SOURCE_DIR}/..
+        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:yolo> ${CMAKE_INSTALL_PREFIX}
         )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,12 +24,24 @@ enable_testing()
 # Copy test files to output directory
 file(COPY resources DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
-# Copy plugins to output plugin directory
-ADD_CUSTOM_COMMAND(TARGET lightdb_test
-        POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/plugins
-        COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/plugins/* ${CMAKE_CURRENT_BINARY_DIR}/plugins
+# Build plugins used by tests
+include(ExternalProject)
+file(GLOB LIGHTDB_PLUGIN_DIRS ${CMAKE_SOURCE_DIR}/plugins/*)
+foreach(LIGHTDB_PLUGIN_DIR ${LIGHTDB_PLUGIN_DIRS})
+    if (IS_DIRECTORY ${LIGHTDB_PLUGIN_DIR})
+        get_filename_component(LIGHTDB_PLUGIN_NAME ${LIGHTDB_PLUGIN_DIR} NAME_WE)
+        ExternalProject_Add(${LIGHTDB_PLUGIN_NAME}
+                PREFIX ${LIGHTDB_PLUGIN_DIR}
+                SOURCE_DIR ${LIGHTDB_PLUGIN_DIR}
+                INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/plugins
+                CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+                EXCLUDE_FROM_ALL TRUE
+                BUILD_ALWAYS TRUE
+                INSTALL_COMMAND ""
         )
+        add_dependencies(lightdb_test ${LIGHTDB_PLUGIN_NAME})
+    endif(IS_DIRECTORY ${LIGHTDB_PLUGIN_DIR})
+endforeach(LIGHTDB_PLUGIN_DIR)
 
 # Copy plugins to output plugin directory
 ADD_CUSTOM_COMMAND(TARGET lightdb_test


### PR DESCRIPTION
Make sure plugins used by the tests are built and copied to the lightdb_test target.

test/CMakeLists.txt:
Iterate over all of the subdirectories under "plugins/" and add
each as a target that lightdb_test depends on so that they are built
when the lightdb_test target is built. Pass INSTALL_DIR, which is set
to the test/plugins directory, to each plugin so that it can copy
itself directly to the correct location in the test directory. Set
BUILD_ALWAYS to true so that if changes are made to any of the plugin's
source files, they will be rebuilt.

plugins/blur/CMakeLists.txt:
Copy the shared library directly to the correct location in the test
directory.

plugins/yolo/CMakeLists.txt:
Ditto. Also add an include statement that was necessary for yolo to
build. The includes should probably eventually reference the current
project's source, but that can happen later.