### PR TITLE
Make Discretize actually scale the output video.

### DIFF
--- a/core/video/include/Configuration.h
+++ b/core/video/include/Configuration.h
@@ -31,6 +31,22 @@ struct Configuration {
     struct {
         unsigned int left, top;
     } offset;
+
+    inline bool operator==(const Configuration &other) const {
+        return this == &other ||
+                (width == other.width &&
+                height == other.height &&
+                max_width == other.max_width &&
+                max_height == other.max_height &&
+                bitrate == other.bitrate &&
+                framerate.fps() == other.framerate.fps() &&
+                offset.left == other.offset.left &&
+                offset.top == other.offset.top);
+    }
+
+    inline bool operator!=(const Configuration &other) const {
+        return !(*this == other);
+    }
 };
 
 struct EncodeConfiguration: public Configuration

--- a/test/src/planning/VisitorTests.cc
+++ b/test/src/planning/VisitorTests.cc
@@ -1,6 +1,8 @@
+#include "AssertVideo.h"
 #include "HeuristicOptimizer.h"
 #include "Greyscale.h"
 #include "Display.h"
+#include "TestResources.h"
 #include "extension.h"
 #include <gtest/gtest.h>
 
@@ -127,4 +129,23 @@ TEST_F(VisitorTestFixture, testPartitionSubqueryUnion) {
     auto encoded = transcoded.Encode(Codec::hevc());
 
     Coordinator().execute(encoded);
+}
+
+TEST_F(VisitorTestFixture, testScanInterpolateDiscretize) {
+    auto outputResolution = 416;
+
+    auto input = Scan(Resources.red10.name);
+    auto continuous = input.Interpolate(Dimension::Theta, interpolation::Linear());
+    auto smallTheta = continuous.Discretize(Dimension::Theta, rational_times_real({2, outputResolution}, PI));
+    auto small = smallTheta.Discretize(Dimension::Phi, rational_times_real({1, outputResolution}, PI));
+    auto saved = small.Save(Resources.out.hevc);
+
+
+    Coordinator().execute(saved);
+
+    EXPECT_VIDEO_VALID(Resources.out.hevc);
+    EXPECT_VIDEO_FRAMES(Resources.out.hevc, Resources.red10.frames);
+    EXPECT_VIDEO_RESOLUTION(Resources.out.hevc, outputResolution, outputResolution);
+    EXPECT_VIDEO_RED(Resources.out.hevc);
+    EXPECT_EQ(remove(Resources.out.hevc), 0);
 }


### PR DESCRIPTION
It was using the same dimensions as the input frame, but it should
be using the discretized dimensions so that the output video is correctly
scaled.

To avoid outputting an `INFO` log for every downsampled frame, I moved the
log statement behind and `if` statement so it only prints if the dimensions change.

It looks like the change to use the input frame dimensions happened in
0c23d0d.